### PR TITLE
Updates feature gate to use new_zeroed_alloc

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@
     maybe_uninit_uninit_array,
     maybe_uninit_array_assume_init,
     portable_simd,
-    new_uninit
+    new_zeroed_alloc
 )]
 #![allow(incomplete_features)]
 #![warn(clippy::all)]


### PR DESCRIPTION
Needed in order to build kelpsyberry/dust#9 with newest nightly

More specific version of new_uninit introduced in rust-lang/rust#129396