### PR TITLE
Replace use of `maybe_uninit_uninit_array` with newly stabilized inline const blocks

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,5 @@
 #![feature(
     generic_const_exprs,
-    maybe_uninit_uninit_array,
     maybe_uninit_array_assume_init,
     portable_simd,
     new_zeroed_alloc

--- a/src/savestate/read.rs
+++ b/src/savestate/read.rs
@@ -365,7 +365,7 @@ where
 {
     #[inline]
     fn load<S: ReadSavestate>(save: &mut S) -> Result<Self, S::Error> {
-        let mut result = MaybeUninit::uninit_array();
+        let mut result = [const { MaybeUninit::uninit() }; LEN];
         for elem in &mut result {
             *elem = MaybeUninit::new(save.load()?);
         }
@@ -393,7 +393,7 @@ where
 {
     #[inline]
     fn load<S: ReadSavestate>(save: &mut S) -> Result<Self, S::Error> {
-        let mut result = MaybeUninit::uninit_array();
+        let mut result = [const { MaybeUninit::uninit() }; LANES];
         for elem in &mut result {
             *elem = MaybeUninit::new(save.load()?);
         }


### PR DESCRIPTION
Thanks for developing dust, its awesome :)

On the latest Rust nightly channel (rustc 1.87.0-nightly (00f245915 2025-02-26)) I was unable to build `emu-utils` and by extension `dust`.

It seems that some time back, `maybe_uninit_uninit_array` has been removed and replaced in functionality with the now stabilized inline const block pattern. See https://github.com/rust-lang/rust/pull/125082

This pull request fixes any uses of that feature, at which point I can once again build the crate